### PR TITLE
[INFRANG-6876] Upgrade to go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/elblog
     docker:
-    - image: circleci/golang:1.16
+    - image: cimg/go:1.24
     steps:
     - checkout
     - run: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Clever/elblog
+    working_directory: ~/go/src/github.com/Clever/elblog
     docker:
     - image: cimg/go:1.24
     steps:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKGS := $(shell go list ./... | grep -v /vendor)
 
 .PHONY: test $(PKGS) run install_deps
 
-$(eval $(call golang-version-check,1.12))
+$(eval $(call golang-version-check,1.24))
 
 test: $(PKGS)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Clever/elblog
 
-go 1.16
+go 1.24

--- a/golang.mk
+++ b/golang.mk
@@ -1,14 +1,17 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.4.0
+GOLANG_MK_VERSION := 1.3.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
-.PHONY: golang-test-deps bin/dep golang-ensure-curl-installed
+.PHONY: golang-test-deps golang-ensure-curl-installed
 
 # set timezone to UTC for golang to match circle and deploys
 export TZ=UTC
+
+# go build flags for use across all commands which accept them
+export GOFLAGS := -mod=vendor $(GOFLAGS)
 
 # if the gopath includes several directories, use only the first
 GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
@@ -32,57 +35,23 @@ _ := $(if  \
 endef
 
 # FGT is a utility that exits with 1 whenever any stderr/stdout output is recieved.
+# We pin its version since its a simple tool that does its job as-is;
+# so we're defended against it breaking or changing in the future.
 FGT := $(GOPATH)/bin/fgt
 $(FGT):
-	go get github.com/GeertJohan/fgt
+	go install -mod=readonly github.com/GeertJohan/fgt@262f7b11eec07dc7b147c44641236f3212fee89d
 
 golang-ensure-curl-installed:
 	@command -v curl >/dev/null 2>&1 || { echo >&2 "curl not installed. Please install curl."; exit 1; }
 
-DEP_VERSION = v0.4.1
-DEP_INSTALLED := $(shell [[ -e "bin/dep" ]] && bin/dep version | grep version | grep -v go | cut -d: -f2 | tr -d '[:space:]')
-# Dep is a tool used to manage Golang dependencies. It is the offical vendoring experiment, but
-# not yet the official tool for Golang.
-ifeq ($(DEP_VERSION),$(DEP_INSTALLED))
-bin/dep: # nothing to do, dep is already up-to-date
-else
-CACHED_DEP = /tmp/dep-$(DEP_VERSION)
-bin/dep: golang-ensure-curl-installed
-	@echo "Updating dep..."
-	@mkdir -p bin
-	@if [ ! -f $(CACHED_DEP) ]; then curl -o $(CACHED_DEP) -sL https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(SYSTEM)-amd64; fi;
-	@cp $(CACHED_DEP) bin/dep
-	@chmod +x bin/dep || true
-endif
-
-# figure out "github.com/<org>/<repo>"
-# `go list` will fail if there are no .go files in the directory
-# if this is the case, fall back to assuming github.com/Clever
-REF = $(shell go list || echo github.com/Clever/$(notdir $(shell pwd)))
-golang-verify-no-self-references:
-	@if grep -q -i "$(REF)" Gopkg.lock; then echo "Error: Gopkg.lock includes a self-reference ($(REF)), which is not allowed. See: https://github.com/golang/dep/issues/1690" && exit 1; fi;
-	@if grep -q -i "$(REF)" Gopkg.toml; then echo "Error: Gopkg.toml includes a self-reference ($(REF)), which is not allowed. See: https://github.com/golang/dep/issues/1690" && exit 1; fi;
-
-golang-dep-vendor-deps: bin/dep golang-verify-no-self-references
-
-# golang-godep-vendor is a target for saving dependencies with the dep tool
-# to the vendor/ directory. All nested vendor/ directories are deleted via
-# the prune command.
-# In CI, -vendor-only is used to avoid updating the lock file.
-ifndef CI
-define golang-dep-vendor
-bin/dep ensure -v
-endef
-else
-define golang-dep-vendor
-bin/dep ensure -v -vendor-only
-endef
-endif
-
 # Golint is a tool for linting Golang code for common errors.
+# We pin its version because an update could add a new lint check which would make
+# previously passing tests start failing without changing our code.
+# this package is deprecated and frozen
+# Infra recommendation is to eventually move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
-	go get golang.org/x/lint/golint
+	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
 
 # golang-fmt-deps requires the FGT tool for checking output
 golang-fmt-deps: $(FGT)
@@ -91,7 +60,7 @@ golang-fmt-deps: $(FGT)
 # arg1: pkg path
 define golang-fmt
 @echo "FORMATTING $(1)..."
-@$(FGT) gofmt -l=true $(GOPATH)/src/$(1)/*.go
+@PKG_PATH=$$(go list -f '{{.Dir}}' $(1)); $(FGT) gofmt -l=true $${PKG_PATH}/*.go
 endef
 
 # golang-lint-deps requires the golint tool for golang linting.
@@ -101,19 +70,11 @@ golang-lint-deps: $(GOLINT)
 # arg1: pkg path
 define golang-lint
 @echo "LINTING $(1)..."
-@find $(GOPATH)/src/$(1)/*.go -type f | grep -v gen_ | xargs $(GOLINT)
+@PKG_PATH=$$(go list -f '{{.Dir}}' $(1)); find $${PKG_PATH}/*.go -type f | grep -v gen_ | xargs $(GOLINT)
 endef
 
 # golang-lint-deps-strict requires the golint tool for golang linting.
 golang-lint-deps-strict: $(GOLINT) $(FGT)
-
-# golang-lint-strict calls golint on all golang files in the pkg and fails if any lint
-# errors are found.
-# arg1: pkg path
-define golang-lint-strict
-@echo "LINTING $(1)..."
-@find $(GOPATH)/src/$(1)/*.go -type f | grep -v gen_ | xargs $(FGT) $(GOLINT)
-endef
 
 # golang-test-deps is here for consistency
 golang-test-deps:
@@ -135,6 +96,21 @@ define golang-test-strict
 @go test -v -race $(1)
 endef
 
+# golang-test-strict-cover-deps is here for consistency
+golang-test-strict-cover-deps:
+
+# golang-test-strict-cover uses the Go toolchain to run all tests in the pkg with the race and cover flag.
+# appends coverage results to coverage.txt
+# arg1: pkg path
+define golang-test-strict-cover
+@echo "TESTING $(1)..."
+@go test -v -race -cover -coverprofile=profile.tmp -covermode=atomic $(1)
+@if [ -f profile.tmp ]; then \
+  cat profile.tmp | tail -n +2 >> coverage.txt; \
+  rm profile.tmp; \
+fi;
+endef
+
 # golang-vet-deps is here for consistency
 golang-vet-deps:
 
@@ -142,7 +118,7 @@ golang-vet-deps:
 # arg1: pkg path
 define golang-vet
 @echo "VETTING $(1)..."
-@go vet $(GOPATH)/src/$(1)/*.go
+@go vet $(1)
 endef
 
 # golang-test-all-deps installs all dependencies needed for different test cases.
@@ -165,25 +141,53 @@ golang-test-all-strict-deps: golang-fmt-deps golang-lint-deps-strict golang-test
 # arg1: pkg path
 define golang-test-all-strict
 $(call golang-fmt,$(1))
-$(call golang-lint-strict,$(1))
+$(call golang-lint,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
 endef
 
-# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# golang-test-all-strict-cover-deps: installs all dependencies needed for different test cases.
+golang-test-all-strict-cover-deps: golang-fmt-deps golang-lint-deps-strict golang-test-strict-cover-deps golang-vet-deps
+
+# golang-test-all-strict-cover calls fmt, lint, vet and test on the specified pkg with strict and cover
+# requirements that no errors are thrown while linting.
+# arg1: pkg path
+define golang-test-all-strict-cover
+$(call golang-fmt,$(1))
+$(call golang-lint,$(1))
+$(call golang-vet,$(1))
+$(call golang-test-strict-cover,$(1))
+endef
+
+# golang-build: builds a golang binary
 # arg1: pkg path
 # arg2: executable name
 define golang-build
-@echo "BUILDING..."
-@if [ -z "$$CI" ]; then \
-	go build -o bin/$(2) $(1); \
-else \
-	echo "-> Building CGO binary"; \
-	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
-fi;
+@echo "BUILDING $(2)..."
+@CGO_ENABLED=0 go build -o bin/$(2) $(1);
 endef
+
+# golang-debug-build: builds a golang binary with debugging capabilities
+# arg1: pkg path
+# arg2: executable name
+define golang-debug-build
+@echo "BUILDING $(2) FOR DEBUG..."
+@CGO_ENABLED=0 go build -gcflags="all=-N -l" -o bin/$(2) $(1);
+endef
+
+# golang-cgo-build: builds a golang binary with CGO
+# arg1: pkg path
+# arg2: executable name
+define golang-cgo-build
+@echo "BUILDING $(2) WITH CGO ..."
+@CGO_ENABLED=1 go build -installsuffix cgo -o bin/$(2) $(1);
+endef
+
+# golang-setup-coverage: set up the coverage file
+golang-setup-coverage:
+	@echo "mode: atomic" > coverage.txt
 
 # golang-update-makefile downloads latest version of golang.mk
 golang-update-makefile:
-	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/golang.mk -O /tmp/golang.mk 2>/dev/null
+	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/golang-v1.mk -O /tmp/golang.mk 2>/dev/null
 	@if ! grep -q $(GOLANG_MK_VERSION) /tmp/golang.mk; then cp /tmp/golang.mk golang.mk && echo "golang.mk updated"; else echo "golang.mk is up-to-date"; fi


### PR DESCRIPTION
<!-- This template should be used as a living PR template for future go migrations -->

# JIRA
https://clever.atlassian.net/browse/INFRANG-6876

# About
This PR upgrades this repo to Go version 1.24. See the [release notes](https://tip.golang.org/doc/go1.24) for full details.

It performs the following changes:
1. Upgrade the module to 1.24.
2. Upgrade the golang.mk file to the latest version.
3. Replaces any `tools.go` file with the new go.mod tools directive.
4. Updates any circle CI build images to 1.24.
5. Updates the go version check in the makefile.
6. Updates any debian docker images to a version with a glibc compatible with the CI build image.



#### New Go Vet Check
Go vet in 1.24 introduces a new check which catches non-constant format strings in calls to printf functions. This has a tendency to find bugs in existing code, however the fix is pretty strait forward should your CI begin to fail. You can see more details in the official issue https://github.com/golang/go/issues/60529. If your CI fails because of this, you may add an extra commit resolving the issue, then merge. The microplane script attempts to resolve as many of these cases as possible automatically.

# Testing
Go version upgrades have historically been extremely stable. The only exception has been incompatible glibc versions which have been tested for in workers before merging. All standard CI testing is also performed before merging.

# Problems Upgrading?
Checkout this [google doc](https://docs.google.com/document/d/1ctg3eT8zkKHXqsf7CCUBB77ERmEVMsyZoYAIxXm19hs/edit?usp=sharing) for knowledge sharing any problems you encounter during upgrades!
